### PR TITLE
fix 話数移動時にコメントが取得できない #70

### DIFF
--- a/src/content_scripts/danime/watch.ts
+++ b/src/content_scripts/danime/watch.ts
@@ -21,7 +21,6 @@ import { find_element, find_elements } from "./dom";
 
 /**
  * 視聴ページで title と description をパートタイトルと説明に書き換える
- * mediaSession を設定する
  */
 export const setWorkInfo = async () => {
   const res = await get_work_info();


### PR DESCRIPTION
話数移動時、動画を再度検索するように修正**

[ダンジョン飯](https://animestore.docomo.ne.jp/animestore/ci_pc?workId=26747) ではニコニコ動画側の content id が話数に従ってに increment されていなかったため、コメントの取得に失敗していた

resolve #70 