### PR TITLE
fix #97 #98

### DIFF
--- a/src/content_scripts/index.ts
+++ b/src/content_scripts/index.ts
@@ -121,8 +121,9 @@ switch (url.pathname) {
     });
 
     on_partId_change(async (prev, next) => {
-      if (prev?.videoId && getThreads() && next) {
+      if (prev && prev.workId !== next?.workId) {
         await setWorkInfo();
+        if (!getThreads()) return;
 
         if (await getConfig("load_comments_on_next_video")) await auto_play();
         else


### PR DESCRIPTION
workIdを比較することで、エピソード移動後にon_partId_changeが2回実行されるのを修正しました。

これにより前のエピソードでコメント表示していない場合でも、setWorkInfo()を実行しウィンドウタイトルを更新するようになりました。 #97 

また「連続再生時に自動で次の動画のコメントを読み込む」が、自動で動画検索がオフの時にも実行されるようになりました。#98 